### PR TITLE
fix: make cta links clickable

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -100,7 +100,7 @@ add_info_card(
     "Are you a justice advocate, public servant, or community legal provider?
     Help us create impactful projects. Or volunteer as a project mentor.", 
   button_text = "Get Involved", 
-  button_link = "#partners"
+  button_link = "/posts/for-organizers.qmd"
 )
 
 add_info_card(

--- a/about.qmd
+++ b/about.qmd
@@ -91,7 +91,7 @@ add_info_card(
     "Free to attend and open to everyone, regardless of coding experience 
     or affiliation with an organization or university.", 
   button_text = "Register", 
-  button_link = "#register"
+  button_link = "https://www.eventbrite.com/e/philadelphias-social-justice-hackathon-tickets-829209476867"
 )
 
 add_info_card(

--- a/about.qmd
+++ b/about.qmd
@@ -76,10 +76,10 @@ add_info_card <- function(title, body, button_text, button_link) {
     div(
       class = "d-flex justify-content-center mb-3",
       #class = "card-footer",
-      tags$button(
+      tags$a(
         class = "btn btn-action btn-primary btn-action-primary justify-content-center",
         button_text,
-        onclick = button_link
+        href = button_link
       )
     )
   )


### PR DESCRIPTION
This PR fixes the links on the 3 boxes at the top of the about page, so the links are clickable (previously they were the onclick of a button) 