### PR TITLE
fix: add CNAME file pointing domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+socialjusticehackathon.com

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,6 +1,9 @@
 project:
   type: website
 
+resources:
+  - CNAME
+
 website:
   title: "#SJHPHL"
   navbar:


### PR DESCRIPTION
This PR ensures each time we deploy, people visiting socialjusticehackathon.com can see the site, by adding a CNAME file. See this [github doc page](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) for details. ([This quarto discussion](https://github.com/quarto-dev/quarto-cli/discussions/3249) for more context)