### PR TITLE
add schedule-venue page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -12,6 +12,7 @@ website:
         text: About
       - href: events.qmd
         text: Events
+      - href: schedule-venue.qmd
       - posts/index.qmd
     right:
       - icon: github

--- a/schedule-venue.qmd
+++ b/schedule-venue.qmd
@@ -1,0 +1,47 @@
+---
+title: "Schedule & Venue"
+format:
+  html:
+    toc: true
+    toc-expand: true
+---
+
+This page has the schedule and address for the main Hackathon event, from April 5th - April 7th. To register for the event, visit the [eventbrite page](https://www.eventbrite.com/e/philadelphia-social-justice-hackathon-2024-tickets-829209476867).
+
+
+## Schedule
+
+| Day | Main Activity | Description |
+| --- | --- | --- |
+| Day 1, Friday, April 5th | Kickoff and Keynote | Hackathon Project Pitches by Project Sponsors and Participants; Team Formation and Matching. |
+| Day 2, Saturday, April 6th | Challenge analysis and planning | Hackathon orientation sessions: design thinking, platforms and data available. Solutions design and development |
+| Day 3, Sunday, April 7th | Solution development and presentation prep | Project Final Submissions.  Judging.  Closing Ceremony |
+
+## Venue
+
+:::::: {.grid}
+
+::: {.g-col-12 .g-col-lg-4}
+Drexel University Thomas R. Kline School of Law  
+3320 Market St  
+Philadelphia, PA 19104
+:::
+
+::: {.g-col-12 .g-col-lg-8}
+
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3058.3732790637437!2d-75.19301808771128!3d39.95540627139878!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c6c651cc8cb83b%3A0xd207bd894c157129!2sDrexel%20University%20Thomas%20R.%20Kline%20School%20of%20Law!5e0!3m2!1sen!2sus!4v1710446008805!5m2!1sen!2sus" width="480" height="360" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+:::
+
+::::::
+
+### Directions
+
+See [this Drexel Directions page](https://drexel.edu/law/admissions/tours-info-sessions-events/Directions/) for more.
+
+### Parking
+
+The Drexel Garage is located next to the law school. Proceed to 34th and Market Streets - there is a traffic light there - (you'll also pass the Law School Building on your left before the light). Turn left onto 34th Street - and make an immediate left onto the next street - Ludlow Street. Turn immediately left up to the entrance ramp to the garage on Ludlow Street. Park, note your place number, and pay at the lobby kiosk. Come down the elevator, exit the building and walk right. The law school is immediately to the right of the garage, just past the front of the parking garage.
+
+Metered parking is also available on many of the surrounding streets. The meters accept quarters, dimes and nickels for timed parking.
+
+


### PR DESCRIPTION
This PR adds a schedule and venue page, which lists details for the April 5th to 7th hackathon.

Here is a preview

![image](https://github.com/socialjusticehackathon/website/assets/2574498/1c1fc600-a7ac-4594-9a29-58b11151c5b0)
