### PR TITLE
Separate past events from upcoming

### DIFF
--- a/events.qmd
+++ b/events.qmd
@@ -4,15 +4,7 @@ title: Events
 
 ::: {.content-block}
 
-#### ~~Challenge Projects and Pizza Night!~~
-~~*Date: March 7, 2024*~~<br>
-~~Speaking: Kevin De Liban, Joy Payton~~<br>
-~~[Register now](https://www.meetup.com/legalhackerspa/events/299578460/)~~
-
-#### Code for Philly Takeover and Pizza
-*Date: March 14, 2024*<br>
-Speaking: Caitlin Sherman, Kat Jost<br>
-[Register now](https://www.eventbrite.com/e/sjhphl-social-justice-projects-with-code-for-philly-pizza-nite-tickets-858595481197)
+## Upcoming Events
 
 #### Open Source Technology in Legal Aid and Pizza
 *Date: March 21, 2024*<br>
@@ -26,4 +18,17 @@ Speaking: Kevin Mulcahy, Travis Southard, Jonathan Pyle<br>
 #### Social Justice Hackathon
 *Date: April 5-7, 2024*<br>
 [Register now](https://www.eventbrite.com/e/philadelphia-social-justice-hackathon-2024-tickets-829209476867)
+
+---
+
+## Past Events
+
+#### ~~Challenge Projects and Pizza Night!~~
+~~*Date: March 7, 2024*~~<br>
+~~Speaking: Kevin De Liban, Joy Payton~~
+
+#### ~~Code for Philly Takeover and Pizza~~
+~~*Date: March 14, 2024*~~<br>
+~~Speaking: Caitlin Sherman, Kat Jost, Iliana Miltiadous~~<br>
+
 :::


### PR DESCRIPTION
# Overview

Separate past events from upcoming events so that the next upcoming event is obvious and top of list. Also preserves record of past events that we could add our zoom recordings to in the future.

### Before:

<img width="871" alt="image" src="https://github.com/socialjusticehackathon/website/assets/64238570/7eaf1341-5cb8-48bc-8934-2c1134665118">

### After:

<img width="1004" alt="image" src="https://github.com/socialjusticehackathon/website/assets/64238570/a3a5158f-05b0-40fc-a7cd-a4793ca3e3fe">
