### PR TITLE
Remove last pre-event

### DIFF
--- a/events.qmd
+++ b/events.qmd
@@ -73,14 +73,6 @@ add_info_card <- function(title, body, button_text, button_link) {
 }
 
 add_info_card(
-  title = "Open Data for Legal Aid Projects", 
-  body = 
-    "Date: March 28, 2024", 
-  button_text = "Register now", 
-  button_link = "https://www.eventbrite.com/e/sjhphl-open-data-for-legal-aid-projects-and-pizza-tickets-860772532817"
-)
-
-add_info_card(
   title = "Social Justice Hackathon", 
   body = 
     "Date: April 5-7, 2024", 

--- a/index.qmd
+++ b/index.qmd
@@ -47,11 +47,11 @@ general_card_div <- function(..., lg = 3, md = 2, sm = 2, xs = 1) {
 ```{r}
 a(
   class="preview-link",
-  href="https://www.eventbrite.com/e/sjhphl-open-data-for-legal-aid-projects-and-pizza-tickets-860772532817",
+  href="https://www.eventbrite.com/e/philadelphias-social-justice-hackathon-tickets-829209476867",
   target="_blank",
   p(
     class="hero-link content-block",
-    HTML("<b>Pre-Hackathon Events:</b> Join us for Open Data for Legal Aid Projects this Thurs, March 28, 2024, at the Drexel Kline School of Law! Learn about challenge projects and data to get ready for the #SJHPHL Hackathon in April")
+    HTML("<b>Register for free!</b> Join us April 5-7 for Philly's 2nd Social Justice Hackathon!")
   )
 )
 ```


### PR DESCRIPTION
# Overview

Removes the last pre-event from the events page and the link above the banner.

The link may be extraneous now, but also fits with the design we have so it could stay or go, but I am open to feedback.