### PR TITLE
fix: iframe remove absolute width

### DIFF
--- a/events.qmd
+++ b/events.qmd
@@ -102,7 +102,7 @@ Philadelphia, PA 19104
 
 ::: {.g-col-12 .g-col-lg-8}
 
-<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3058.3732790637437!2d-75.19301808771128!3d39.95540627139878!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c6c651cc8cb83b%3A0xd207bd894c157129!2sDrexel%20University%20Thomas%20R.%20Kline%20School%20of%20Law!5e0!3m2!1sen!2sus!4v1710446008805!5m2!1sen!2sus" width="480" height="360" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3058.3732790637437!2d-75.19301808771128!3d39.95540627139878!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c6c651cc8cb83b%3A0xd207bd894c157129!2sDrexel%20University%20Thomas%20R.%20Kline%20School%20of%20Law!5e0!3m2!1sen!2sus!4v1710446008805!5m2!1sen!2sus" width="100%" height="360" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
 
 :::
 


### PR DESCRIPTION
This PR prevents the iframe with a map of the event location from breaking its container width, due to absolute width